### PR TITLE
add some more test coverage, rewrite benchmarks

### DIFF
--- a/loglater_test.go
+++ b/loglater_test.go
@@ -256,7 +256,7 @@ func TestErrorHandling(t *testing.T) {
 		collector := NewLogCollector(nil)
 		logger := slog.New(collector)
 
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			logger.Info("Test message", "index", i)
 		}
 

--- a/storage/options_test.go
+++ b/storage/options_test.go
@@ -152,7 +152,7 @@ func TestWithContext(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 
 	// Add more records to exceed max size
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		store.Append(createTestRecord(time.Now(), slog.LevelInfo, "New Message"))
 	}
 

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1,7 +1,6 @@
 package storage
 
 import (
-	"context"
 	"log/slog"
 	"sync"
 	"testing"
@@ -111,7 +110,7 @@ func BenchmarkRecordStorage_GetAll(b *testing.B) {
 				}
 				b.ResetTimer()
 				for b.Loop() {
-					for i := 0; i < tc.gets; i++ {
+					for range tc.gets {
 						_ = store.GetAll()
 					}
 				}
@@ -244,6 +243,33 @@ func TestRecordStorage(t *testing.T) {
 			t.Errorf("Expected 3 attributes, got %d", len(record.Attrs))
 		}
 
+		attr1 := record.Attrs[0]
+		attr2 := record.Attrs[1]
+		attr3 := record.Attrs[2]
+
+		if attr1.Value.Kind() != slog.KindString {
+			t.Errorf("Expected string attribute, got %v", attr1.Value.Kind())
+		}
+
+		if attr1.Value.String() != "value" {
+			t.Errorf("Expected string attribute value 'value', got %q", attr1.Value.String())
+		}
+
+		if attr2.Value.Kind() != slog.KindInt64 {
+			t.Errorf("Expected int attribute, got %v", attr2.Value.Kind())
+		}
+
+		if attr2.Value.Int64() != 42 {
+			t.Errorf("Expected int attribute value 42, got %d", attr2.Value.Int64())
+		}
+
+		if attr3.Value.Kind() != slog.KindBool {
+			t.Errorf("Expected bool attribute, got %v", attr3.Value.Kind())
+		}
+
+		if attr3.Value.Bool() != true {
+			t.Errorf("Expected bool attribute value true, got %v", attr3.Value.Bool())
+		}
 	})
 
 	t.Run("NewRecord", func(t *testing.T) {
@@ -255,7 +281,7 @@ func TestRecordStorage(t *testing.T) {
 		)
 
 		// Create a new Record
-		record := NewRecord(context.Background(), nil, &r)
+		record := NewRecord(t.Context(), nil, &r)
 
 		// Verify basic fields
 		if record.Message != "test message" {
@@ -271,6 +297,24 @@ func TestRecordStorage(t *testing.T) {
 			t.Errorf("Expected 2 attributes, got %d", len(record.Attrs))
 		}
 
+		attr1 := record.Attrs[0]
+		attr2 := record.Attrs[1]
+
+		if attr1.Value.Kind() != slog.KindString {
+			t.Errorf("Expected string attribute, got %v", attr1.Value.Kind())
+		}
+
+		if attr1.Value.String() != "value1" {
+			t.Errorf("Expected string attribute value 'value1', got %q", attr1.Value.String())
+		}
+
+		if attr2.Value.Kind() != slog.KindInt64 {
+			t.Errorf("Expected int attribute, got %v", attr2.Value.Kind())
+		}
+
+		if attr2.Value.Int64() != 42 {
+			t.Errorf("Expected int attribute value 42, got %d", attr2.Value.Int64())
+		}
 	})
 
 	t.Run("ConcurrentAccess", func(t *testing.T) {


### PR DESCRIPTION
```shell
❯ make bench
go test -benchmem -run="^$" -bench=. ./...
PASS
ok  	github.com/robbyt/go-loglater	0.009s
PASS
ok  	github.com/robbyt/go-loglater/examples/group	0.009s
PASS
ok  	github.com/robbyt/go-loglater/examples/options	0.009s
PASS
ok  	github.com/robbyt/go-loglater/examples/simple	0.008s
goos: darwin
goarch: amd64
pkg: github.com/robbyt/go-loglater/storage
cpu: Intel(R) Xeon(R) W-3275M CPU @ 2.50GHz
BenchmarkCleanup_MaxSize/InitialSize_0_MaxSize_10_Records_1000/Sync-56    	   12066	     99878 ns/op	  191234 B/op	      83 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_0_MaxSize_10_Records_1000/Async-56   	    8362	    134138 ns/op	  267286 B/op	      12 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_0_MaxSize_10_Records_1000/Sync_Concurrent-56         	     949	   1295558 ns/op	  193998 B/op	      83 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_0_MaxSize_10_Records_1000/Async_Concurrent-56        	     973	   1224247 ns/op	  267250 B/op	      11 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_0_MaxSize_100_Records_1000/Sync-56                   	    8828	    139188 ns/op	  211456 B/op	      12 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_0_MaxSize_100_Records_1000/Async-56                  	   11625	    107395 ns/op	  267251 B/op	      12 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_0_MaxSize_100_Records_1000/Sync_Concurrent-56        	    1008	   1187047 ns/op	  211478 B/op	      12 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_0_MaxSize_100_Records_1000/Async_Concurrent-56       	     949	   1212034 ns/op	  267158 B/op	      11 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_0_MaxSize_1000_Records_1000/Sync-56                  	    6866	    157409 ns/op	  266752 B/op	       7 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_0_MaxSize_1000_Records_1000/Async-56                 	   12676	    103203 ns/op	  267253 B/op	      12 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_0_MaxSize_1000_Records_1000/Sync_Concurrent-56       	    1027	   1202399 ns/op	  266752 B/op	       7 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_0_MaxSize_1000_Records_1000/Async_Concurrent-56      	     963	   1208922 ns/op	  267104 B/op	      10 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_100_MaxSize_10_Records_1000/Sync-56                  	    9246	    124207 ns/op	  191232 B/op	      83 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_100_MaxSize_10_Records_1000/Async-56                 	   14346	     86270 ns/op	  229469 B/op	       3 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_100_MaxSize_10_Records_1000/Sync_Concurrent-56       	     932	   1347508 ns/op	  195372 B/op	      90 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_100_MaxSize_10_Records_1000/Async_Concurrent-56      	     990	   1207584 ns/op	  236473 B/op	       7 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_100_MaxSize_100_Records_1000/Sync-56                 	    9206	    114805 ns/op	  195840 B/op	       9 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_100_MaxSize_100_Records_1000/Async-56                	   13860	     88225 ns/op	  229463 B/op	       3 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_100_MaxSize_100_Records_1000/Sync_Concurrent-56      	     980	   1291552 ns/op	  196555 B/op	      16 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_100_MaxSize_100_Records_1000/Async_Concurrent-56     	    1030	   1201245 ns/op	  229850 B/op	       7 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_100_MaxSize_1000_Records_1000/Sync-56                	   10000	    112739 ns/op	  229376 B/op	       3 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_100_MaxSize_1000_Records_1000/Async-56               	   13958	     86296 ns/op	  229448 B/op	       3 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_100_MaxSize_1000_Records_1000/Sync_Concurrent-56     	     951	   1254824 ns/op	  229376 B/op	       3 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_100_MaxSize_1000_Records_1000/Async_Concurrent-56    	     999	   1183866 ns/op	  229773 B/op	       7 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_1000_MaxSize_10_Records_10000/Sync-56                	     834	   1455057 ns/op	 1919232 B/op	     833 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_1000_MaxSize_10_Records_10000/Async-56               	     622	   1712853 ns/op	 5750891 B/op	       9 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_1000_MaxSize_10_Records_10000/Sync_Concurrent-56     	      90	  13419927 ns/op	 1957297 B/op	     967 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_1000_MaxSize_10_Records_10000/Async_Concurrent-56    	      93	  14598085 ns/op	 4846500 B/op	      65 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_1000_MaxSize_100_Records_10000/Sync-56               	     843	   1395151 ns/op	 2001920 B/op	      92 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_1000_MaxSize_100_Records_10000/Async-56              	     626	   1680335 ns/op	 5756498 B/op	       9 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_1000_MaxSize_100_Records_10000/Sync_Concurrent-56    	     100	  13402629 ns/op	 2011918 B/op	     192 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_1000_MaxSize_100_Records_10000/Async_Concurrent-56   	      90	  14261811 ns/op	 4842475 B/op	      90 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_1000_MaxSize_1000_Records_10000/Sync-56              	     604	   1818094 ns/op	 3112960 B/op	      20 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_1000_MaxSize_1000_Records_10000/Async-56             	     627	   1669009 ns/op	 5763907 B/op	       9 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_1000_MaxSize_1000_Records_10000/Sync_Concurrent-56   	     100	  13760690 ns/op	 3125462 B/op	     150 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_1000_MaxSize_1000_Records_10000/Async_Concurrent-56  	     100	  13836454 ns/op	 5757757 B/op	      90 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_10000_MaxSize_10_Records_100000/Sync-56              	      70	  14404808 ns/op	19199232 B/op	    8333 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_10000_MaxSize_10_Records_100000/Async-56             	      51	  22479380 ns/op	51065724 B/op	      22 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_10000_MaxSize_10_Records_100000/Sync_Concurrent-56   	       7	 153245807 ns/op	19436493 B/op	    8425 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_10000_MaxSize_10_Records_100000/Async_Concurrent-56  	       6	 187264342 ns/op	50141354 B/op	      73 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_10000_MaxSize_100_Records_100000/Sync-56             	     100	  12653974 ns/op	19975680 B/op	     918 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_10000_MaxSize_100_Records_100000/Async-56            	      43	  27239471 ns/op	51108363 B/op	      23 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_10000_MaxSize_100_Records_100000/Sync_Concurrent-56  	       8	 151963055 ns/op	20002928 B/op	     950 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_10000_MaxSize_100_Records_100000/Async_Concurrent-56 	       6	 175793978 ns/op	52426800 B/op	      44 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_10000_MaxSize_1000_Records_100000/Sync-56            	     100	  18152650 ns/op	31440896 B/op	     202 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_10000_MaxSize_1000_Records_100000/Async-56           	      44	  26189272 ns/op	51064087 B/op	      21 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_10000_MaxSize_1000_Records_100000/Sync_Concurrent-56 	       7	 169232168 ns/op	31446230 B/op	     257 allocs/op
BenchmarkCleanup_MaxSize/InitialSize_10000_MaxSize_1000_Records_100000/Async_Concurrent-56         	       6	 195151899 ns/op	53307253 B/op	      26 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_0_MaxAge_10ms_Records_100/Sync-56                              	   50203	     25049 ns/op	   37376 B/op	       4 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_0_MaxAge_10ms_Records_100/Async-56                             	   78200	     14417 ns/op	   37846 B/op	       9 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_0_MaxAge_10ms_Records_100/Sync_Concurrent-56                   	    9332	    133431 ns/op	   37376 B/op	       4 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_0_MaxAge_10ms_Records_100/Async_Concurrent-56                  	   10000	    100474 ns/op	   37452 B/op	       4 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_0_MaxAge_100ms_Records_100/Sync-56                             	   48182	     24997 ns/op	   37376 B/op	       4 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_0_MaxAge_100ms_Records_100/Async-56                            	   78358	     14105 ns/op	   37834 B/op	       9 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_0_MaxAge_100ms_Records_100/Sync_Concurrent-56                  	    9548	    131804 ns/op	   37380 B/op	       4 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_0_MaxAge_100ms_Records_100/Async_Concurrent-56                 	   10000	    101460 ns/op	   37449 B/op	       4 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_0_MaxAge_1s_Records_100/Sync-56                                	   48114	     24751 ns/op	   37376 B/op	       4 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_0_MaxAge_1s_Records_100/Async-56                               	   82021	     14471 ns/op	   37856 B/op	       9 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_0_MaxAge_1s_Records_100/Sync_Concurrent-56                     	    9873	    132321 ns/op	   37379 B/op	       4 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_0_MaxAge_1s_Records_100/Async_Concurrent-56                    	   10000	    101042 ns/op	   37448 B/op	       4 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_100_MaxAge_10ms_Records_1000/Sync-56                           	    6513	    229172 ns/op	  266582 B/op	       6 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_100_MaxAge_10ms_Records_1000/Async-56                          	   12188	     98936 ns/op	  267245 B/op	      12 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_100_MaxAge_10ms_Records_1000/Sync_Concurrent-56                	     862	   1433074 ns/op	  265854 B/op	       9 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_100_MaxAge_10ms_Records_1000/Async_Concurrent-56               	    1023	   1235787 ns/op	  229623 B/op	       5 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_100_MaxAge_100ms_Records_1000/Sync-56                          	    5821	    228668 ns/op	  266752 B/op	       7 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_100_MaxAge_100ms_Records_1000/Async-56                         	   10000	    102933 ns/op	  267249 B/op	      12 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_100_MaxAge_100ms_Records_1000/Sync_Concurrent-56               	     884	   1417556 ns/op	  266971 B/op	       9 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_100_MaxAge_100ms_Records_1000/Async_Concurrent-56              	    1023	   1212016 ns/op	  229677 B/op	       5 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_100_MaxAge_1s_Records_1000/Sync-56                             	    6474	    229143 ns/op	  266752 B/op	       7 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_100_MaxAge_1s_Records_1000/Async-56                            	   10000	    103399 ns/op	  267252 B/op	      12 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_100_MaxAge_1s_Records_1000/Sync_Concurrent-56                  	     879	   1352784 ns/op	  266752 B/op	       7 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_100_MaxAge_1s_Records_1000/Async_Concurrent-56                 	    1056	   1186820 ns/op	  229716 B/op	       5 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_1000_MaxAge_10ms_Records_10000/Sync-56                         	     420	   2884778 ns/op	 4459476 B/op	      14 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_1000_MaxAge_10ms_Records_10000/Async-56                        	     781	   1505037 ns/op	 4600970 B/op	      19 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_1000_MaxAge_10ms_Records_10000/Sync_Concurrent-56              	      93	  12235040 ns/op	 1413939 B/op	      33 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_1000_MaxAge_10ms_Records_10000/Async_Concurrent-56             	      88	  13311602 ns/op	 4320607 B/op	      61 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_1000_MaxAge_100ms_Records_10000/Sync-56                        	     403	   2980662 ns/op	 4616704 B/op	      15 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_1000_MaxAge_100ms_Records_10000/Async-56                       	     766	   1522783 ns/op	 4617080 B/op	      19 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_1000_MaxAge_100ms_Records_10000/Sync_Concurrent-56             	     100	  13850629 ns/op	 4620869 B/op	      58 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_1000_MaxAge_100ms_Records_10000/Async_Concurrent-56            	      94	  13523130 ns/op	 4353836 B/op	      48 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_1000_MaxAge_1s_Records_10000/Sync-56                           	     391	   3037240 ns/op	 4616704 B/op	      15 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_1000_MaxAge_1s_Records_10000/Async-56                          	     799	   1477554 ns/op	 4617075 B/op	      19 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_1000_MaxAge_1s_Records_10000/Sync_Concurrent-56                	      86	  14067945 ns/op	 4621634 B/op	      66 allocs/op
BenchmarkCleanup_MaxAge/InitialSize_1000_MaxAge_1s_Records_10000/Async_Concurrent-56               	      92	  13558002 ns/op	 4354715 B/op	      57 allocs/op
BenchmarkCleanup_MixedWorkload/InitialSize_100_MaxSize_50_Records_1000_ReadRatio_50/Sync-56        	     589	   2169569 ns/op	 2933503 B/op	     515 allocs/op
BenchmarkCleanup_MixedWorkload/InitialSize_100_MaxSize_50_Records_1000_ReadRatio_50/Async-56       	     356	   3224700 ns/op	 5667444 B/op	     511 allocs/op
BenchmarkCleanup_MixedWorkload/InitialSize_100_MaxSize_50_Records_1000_ReadRatio_90/Sync-56        	     496	   2279205 ns/op	 4934246 B/op	     912 allocs/op
BenchmarkCleanup_MixedWorkload/InitialSize_100_MaxSize_50_Records_1000_ReadRatio_90/Async-56       	     362	   2997422 ns/op	 8716833 B/op	     915 allocs/op
BenchmarkCleanup_MixedWorkload/InitialSize_1000_MaxSize_500_Records_1000_ReadRatio_50/Sync-56      	     144	   8285355 ns/op	28854218 B/op	     522 allocs/op
BenchmarkCleanup_MixedWorkload/InitialSize_1000_MaxSize_500_Records_1000_ReadRatio_50/Async-56     	     100	  11500327 ns/op	42926765 B/op	     525 allocs/op
BenchmarkCleanup_MixedWorkload/InitialSize_1000_MaxSize_500_Records_1000_ReadRatio_90/Sync-56      	      79	  14307113 ns/op	51701979 B/op	     923 allocs/op
BenchmarkCleanup_MixedWorkload/InitialSize_1000_MaxSize_500_Records_1000_ReadRatio_90/Async-56     	      73	  16584021 ns/op	68579229 B/op	     921 allocs/op
BenchmarkCleanup_MixedWorkload/InitialSize_10000_MaxSize_5000_Records_10000_ReadRatio_50/Sync-56   	       5	 216146742 ns/op	2623460569 B/op	    5058 allocs/op
BenchmarkCleanup_MixedWorkload/InitialSize_10000_MaxSize_5000_Records_10000_ReadRatio_50/Async-56  	       7	 155196640 ns/op	2624247195 B/op	    5011 allocs/op
BenchmarkCleanup_MixedWorkload/InitialSize_10000_MaxSize_5000_Records_10000_ReadRatio_90/Sync-56   	       4	 334689024 ns/op	4719271520 B/op	    9082 allocs/op
BenchmarkCleanup_MixedWorkload/InitialSize_10000_MaxSize_5000_Records_10000_ReadRatio_90/Async-56  	       5	 232343262 ns/op	4719374368 B/op	    9095 allocs/op
BenchmarkNewRecord/WithoutAttrs-56                                                                 	11925270	       101.7 ns/op	     112 B/op	       1 allocs/op
BenchmarkNewRecord/With3Attrs-56                                                                   	 5487667	       232.3 ns/op	     240 B/op	       2 allocs/op
BenchmarkNewRecord/With10Attrs-56                                                                  	  517452	      2681 ns/op	    1296 B/op	      26 allocs/op
BenchmarkNewRecord/WithJournal-56                                                                  	 8181837	       153.6 ns/op	     160 B/op	       2 allocs/op
BenchmarkRecordRealize/NoJournal-56                                                                	14297264	        71.87 ns/op	      48 B/op	       1 allocs/op
BenchmarkRecordRealize/SimpleJournal-56                                                            	 3185725	       384.5 ns/op	     288 B/op	       6 allocs/op
BenchmarkRecordRealize/ComplexJournal-56                                                           	  861582	      1918 ns/op	    2000 B/op	      23 allocs/op
BenchmarkApplyGroups/NoGroups-56                                                                   	163101049	         7.344 ns/op	       0 B/op	       0 allocs/op
BenchmarkApplyGroups/SingleGroup-56                                                                	 8834394	       127.0 ns/op	      96 B/op	       2 allocs/op
BenchmarkApplyGroups/ThreeGroups-56                                                                	 3038888	       384.0 ns/op	     288 B/op	       6 allocs/op
BenchmarkApplyGroups/FiveGroups-56                                                                 	 1982524	       610.7 ns/op	     480 B/op	      10 allocs/op
BenchmarkRecordStorage_Append/Synchronous/0-56                                                     	  569863	      1845 ns/op	    5485 B/op	       0 allocs/op
BenchmarkRecordStorage_Append/Synchronous/1-56                                                     	  635972	      2020 ns/op	    6145 B/op	       0 allocs/op
BenchmarkRecordStorage_Append/Synchronous/10-56                                                    	  723349	      1721 ns/op	    5452 B/op	       0 allocs/op
BenchmarkRecordStorage_Append/Synchronous/20-56                                                    	  566197	      1859 ns/op	    5571 B/op	       0 allocs/op
BenchmarkRecordStorage_Append/Asynchronous/0-56                                                    	  125997	      8085 ns/op	    5517 B/op	      11 allocs/op
BenchmarkRecordStorage_Append/Asynchronous/1-56                                                    	  134977	      7718 ns/op	    6388 B/op	      11 allocs/op
BenchmarkRecordStorage_Append/Asynchronous/10-56                                                   	  135627	      7826 ns/op	    6415 B/op	      11 allocs/op
BenchmarkRecordStorage_Append/Asynchronous/20-56                                                   	  128806	      8265 ns/op	    6737 B/op	      11 allocs/op
BenchmarkRecordStorage_GetAll/Synchronous/0-56                                                     	64069317	        17.45 ns/op	       0 B/op	       0 allocs/op
BenchmarkRecordStorage_GetAll/Synchronous/1-56                                                     	12036703	        91.72 ns/op	     112 B/op	       1 allocs/op
BenchmarkRecordStorage_GetAll/Synchronous/10-56                                                    	 2337721	       503.4 ns/op	    1152 B/op	       1 allocs/op
BenchmarkRecordStorage_GetAll/Synchronous/20-56                                                    	 1288414	       959.0 ns/op	    2304 B/op	       1 allocs/op
BenchmarkRecordStorage_GetAll/Asynchronous/0-56                                                    	  243099	      4776 ns/op	     256 B/op	      11 allocs/op
BenchmarkRecordStorage_GetAll/Asynchronous/1-56                                                    	  218116	      5757 ns/op	    1376 B/op	      21 allocs/op
BenchmarkRecordStorage_GetAll/Asynchronous/10-56                                                   	  111296	      9965 ns/op	   11776 B/op	      21 allocs/op
BenchmarkRecordStorage_GetAll/Asynchronous/20-56                                                   	   82674	     14320 ns/op	   23296 B/op	      21 allocs/op
PASS
ok  	github.com/robbyt/go-loglater/storage	262.548s
```